### PR TITLE
feat: Added a new config option to specify default source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ media_player:
     name: Great Room
     host: "192.168.1.123"
     channel: 1 
+    on_source: "Source 1 name"
     source_list:
       - "Source 1 name"
       - "Source 2 name"
@@ -19,12 +20,13 @@ media_player:
       - "Source 4 name"
 ````
 ### Available configuration parameters
-* **platform** (Required): Name of a platform
-* **host** (Required):  IP address of a Control 4 Amp
-* **port**(Optional): port of Control4 Amp. Defaults to 8750
+* **platform** (Required): Name of a platform.
+* **host** (Required):  IP address of a Control 4 Amp.
+* **port**(Optional): port of Control4 Amp. Defaults to 8750.
 * **channel** (Required): Output channel of the AMP. 
-* **on_volume** (Optional): Default volume for the amp to turn on to. 5 if omitted
-* **source_list** (Optional): List of source names in source order (e.g., first name = source 1 on amp, second name = source 2 on amp)
+* **on_volume** (Optional): Default volume for the amp to turn on to. 5 if omitted.
+* **on_source** (Optional): Default source for the amp to select when a zone is turned on. Defaults to the first item in the source_list if unspecified.
+* **source_list** (Optional): List of source names in source order (e.g., first name = source 1 on amp, second name = source 2 on amp).
 
 #### My Home Assistant Card
 ![MyCard](https://github.com/Hansen8601/control4-mediaplayer/blob/f7d66aa66f89b2b0bcf36ea5393bb76a07da0f32/Control4AmpCard.png)

--- a/custom_components/control4-media-player/control4Amp.py
+++ b/custom_components/control4-media-player/control4Amp.py
@@ -28,11 +28,11 @@ def send_udp_command(command, host, port):
 class control4AmpChannel(object):
 # Represents a channel of a Control 4 Matrix Amp
 
-    def __init__(self, host, port, channel):
+    def __init__(self, host, port, channel, source):
         self._host = host
         self._port = port
         self._channel = channel
-        self._source = 1
+        self._source = source
         self._volume = 0
 
     @property
@@ -81,4 +81,3 @@ class control4AmpChannel(object):
 
     def turn_off(self):
         return send_udp_command("c4.amp.out 0" + str(self._channel) + " 00", self._host, self._port)
-


### PR DESCRIPTION
Hey there! Thank you so much for this component! It's made a HUGE difference in my setup :) This is just a convenience PR for allowing a default source to be customized in the `configuration.yaml`. (Got tired of setting it manually every time, and thought perhaps someone else might benefit from my changes as well :)) Feel free to accept, reject, or suggest changes. Thanks again!

# Changes
- Added a new config option to allow integrators to specify a default source for different zones
- Updated the README.md to reflect the new change 
- Updated the README.md to reflect other parameters included in the config